### PR TITLE
fix: Added image_user validation

### DIFF
--- a/src/components/ProfileComponent/ProfileComponent.js
+++ b/src/components/ProfileComponent/ProfileComponent.js
@@ -8,7 +8,7 @@ const ProfileComponent = ({ profileInfo  }) => (
   <div className={styles.userprofile_container}>
     <div className={styles.up_container}>
       <div className={styles.img_container}>
-        <img src={profileInfo.profile ? profileInfo.profile.image_user : defaultUserIcon}
+        <img src={profileInfo.profile && profileInfo.profile.image_user ? profileInfo.profile.image_user : defaultUserIcon}
           alt="profile" />
       </div>
     </div>


### PR DESCRIPTION
Cambiada validación para cuando creas un usuario que se muestre correctamente la imagen de perfil por defecto.

![imagen](https://user-images.githubusercontent.com/24435223/66865879-7811a300-ef98-11e9-9da2-19055a23c621.png)
